### PR TITLE
fotfix for knowmanifest delete conflict

### DIFF
--- a/internal/dataservice/dataservice.go
+++ b/internal/dataservice/dataservice.go
@@ -309,7 +309,7 @@ func UndeployDataService(manifestUniqueID model.ManifestUniqueID, command string
 
 func UndeployAll() error {
 	knownManifests := manifest.GetKnownManifests()
-	log.Info(knownManifests)
+	log.Info("Undeploying all edge apps ", knownManifests)
 
 	for _, manif := range knownManifests {
 		err := UndeployDataService(manif.ManifestUniqueID, CMDRemove)

--- a/internal/manifest/status.go
+++ b/internal/manifest/status.go
@@ -19,9 +19,13 @@ func GetKnownManifests() []model.ManifestStatus {
 }
 
 func DeleteKnownManifest(manifestUniqueID model.ManifestUniqueID) {
+	var filteredKnownManifests []model.ManifestStatus
+
 	linq.From(knownManifests).Where(func(c interface{}) bool {
 		return c.(model.ManifestStatus).ManifestUniqueID != manifestUniqueID
-	}).ToSlice(&knownManifests)
+	}).ToSlice(&filteredKnownManifests)
+
+	knownManifests = filteredKnownManifests
 
 	err := writeKnownManifestsToFile()
 	if err != nil {


### PR DESCRIPTION
Fixed memory conflict caused by using &knownManifests address twice 